### PR TITLE
🚀 feature: make apiId and apiSecret optional

### DIFF
--- a/src/@cardbrother/tencent-cloud-sdk/tencent-cloud.interface.ts
+++ b/src/@cardbrother/tencent-cloud-sdk/tencent-cloud.interface.ts
@@ -32,8 +32,8 @@ export const TENCENT_CLOUD_MODULE_OPTIONS_TOKEN = 'TENCENT_CLOUD_MODULE_OPTIONS_
  * @description TencentCloudModuleOptions is an interface for the options that can be passed to the `forRoot` method of the `TencentCloudModule`.
  */
 export interface TencentCloudModuleOptions {
-  apiId: string;
-  apiSecret: string;
+  apiId?: string;
+  apiSecret?: string;
   region?: string;
   global?: true;
   profile?: ClientProfile;

--- a/src/@cardbrother/tencent-cloud-sdk/tests/cos-client.e2e.spec.ts
+++ b/src/@cardbrother/tencent-cloud-sdk/tests/cos-client.e2e.spec.ts
@@ -24,8 +24,7 @@ describe('@cardbrother/tencentCloudModule COS Test', () => {
       ],
     }).compile();
 
-    tencentCloudService =
-      moduleFixture.get<TencentCloudService>(TencentCloudService);
+    tencentCloudService = moduleFixture.get<TencentCloudService>(TencentCloudService);
   });
 
   it('should be defined', () => {


### PR DESCRIPTION
- Updates the `TencentCloudModuleOptions` interface to make
  `apiId` and `apiSecret` optional, allowing more flexibility in
  module configuration.

- This change improves ease of use, enabling configurations
  that do not require these fields.
